### PR TITLE
Add "TRONE Indication" strawman.

### DIFF
--- a/draft-thoji-scone-trone-protocol.md
+++ b/draft-thoji-scone-trone-protocol.md
@@ -310,7 +310,7 @@ This transport parameter is valid for QUIC versions 1 {{QUIC}} and 2
 transport parameters, and frame types registries established in {{Sections 22.2,
 22.3, and 22.4 of QUIC}}.
 
-# TRONE Indication
+# TRONE Indication {#trone-indication}
 
 QUIC endpoints can signal potential support for TRONE before the completion of
 the QUIC handshake by attaching a TRONE indication packet after a QUIC Initial
@@ -563,7 +563,7 @@ network element applied a rate limit signal.
 
 Network elements can detect potential TRONE support early in a connection by
 looking for TRONE indication packets attached to Initial packets, as described
-in {{TRONE Indication}}. This avoids the need for deep packet inspection of the
+in {{trone-indication}}. This avoids the need for deep packet inspection of the
 TLS handshake.
 
 

--- a/draft-thoji-scone-trone-protocol.md
+++ b/draft-thoji-scone-trone-protocol.md
@@ -386,12 +386,12 @@ indication:
 is_quic = is_quic_datagram(datagram)
 if is_quic and datagram_length > MIN_INITIAL_SIZE:
   last_byte = datagram[datagram_length - 1]
-  
+
   if (last_byte & 0x80) == 0x80:
     version_start = datagram_length - 8
     version_end = datagram_length - 4
     potential_version = datagram[version_start:version_end]
-    
+
     if potential_version == TRONE1_VERSION or potential_version == TRONE2_VERSION:
       note_potential_trone_support(flow_tuple)
 ~~~

--- a/draft-thoji-scone-trone-protocol.md
+++ b/draft-thoji-scone-trone-protocol.md
@@ -313,11 +313,16 @@ transport parameters, and frame types registries established in {{Sections 22.2,
 # TRONE Indication {#trone-indication}
 
 QUIC endpoints can signal potential support for TRONE before the completion of
-the QUIC handshake by attaching a TRONE indication packet after a QUIC Initial
-packet in the first UDP datagram. The TRONE indication provides an
+the QUIC handshake by attaching a TRONE indication packet after the last QUIC
+long header packet in the first UDP datagram. The TRONE indication provides an
 opportunistic signal to network elements that the client might support TRONE.
 Network elements can use this as an early hint, but must await confirmation of
 TRONE support by observing a full TRONE packet after the handshake completes.
+
+When sending QUIC short header packets in the first flight, endpoints SHOULD
+send them separately from the first datagram carrying the TRONE indication
+packet, to avoid receivers incapable of decoding TRONE packets from dropping
+the short header packet.
 
 ## TRONE Indication Packet
 


### PR DESCRIPTION
As discussed in the meeting, and mentioned in #5, it is useful for an endpoint to signal its potential usage of TRONE to a network element. This initial pass uses a "TRONE Indication" packet which is probably excessive but is a fully reversed TRONE packet that's meant to go at the end of a datagram. This allows for the network element to first detect a QUIC initial, and then check the end of the packet for TRONE.

An alternative would be a more bespoke indicating like a concatenation of versions, or something like that.