### PR TITLE
Add a minimum rate algorithm

### DIFF
--- a/draft-ietf-scone-protocol.md
+++ b/draft-ietf-scone-protocol.md
@@ -381,7 +381,7 @@ the throughput advice that is received on datagrams with one marking
 might not apply to datagrams that have different markings.
 
 
-## Lowest Rate Algorithm
+## Lowest Rate Algorithm {#algorithm}
 
 An endpoint that receives throughput advice
 might receive multiple different rate limits.
@@ -394,13 +394,15 @@ remains within throughput advice
 using a lowest rate algorithm as follows.
 
 To operate this algorithm,
-the minimal state that a sender maintains is
+the minimal state that an application --
+which is often, but not always a sender --
+maintains is
 * the current rate limit,
 * any state necessary to monitor throughput
   (that is, throughput usage state, such as the state in {{sliding-window}}), and
 * the time at which that rate limit was last updated.
 
-When a SCONE packet containing updated advice is received:
+When updated advice is received:
 
 * If the signaled rate is the same as the current rate,
   set the last update time to the current time.
@@ -421,17 +423,17 @@ When a SCONE packet containing updated advice is received:
 
 * If the signaled rate is lower than the current value,
   set the current rate limit to match the advice,
-  discard all rate monitoring state,
+  optionally discard all rate monitoring state,
   and set the last update time to the current time.
 
-Senders MUST discard throughput usage state when reducing rates.
+Applications MAY discard throughput usage state when reducing rates.
 Otherwise, data that was sent at a higher rate
-might force the updated send rate to zero; see also {{policing}}.
+might force the available rate to zero; see also {{policing}}.
 Even though loss of information about recent send rate
 might result in temporarily exceeding the rates indicated by throughput advice,
 the relatively long duration of the monitoring period
 means that this is preferable to disabling sending completely.
-Senders MUST retain throughput usage state when increasing state.
+Applications retain throughput usage state when increasing state.
 
 This approach ensures that network elements
 are able to reduce the frequency with which they send updated signals
@@ -592,6 +594,14 @@ enforcing adherence to the advice as though it were a hard limit.
 However, this risks creating a situation where communication ceases entirely
 for a significant period of time;
 that is, up to the period defined in {{time}}.
+
+A network element that reduces the throughput advice it provides
+MUST also discard any state it maintains
+about the consumption of that throughput.
+This is necessary to allow senders to discard state
+when advice is reduced (see {{algorithm}}).
+This avoids cases where an application that has planned usage
+might otherwise be completely unable to send due to a lower limits.
 
 A better approach is to disregard any data that was transmitted
 before engaging any hard limits to throughput.

--- a/draft-ietf-scone-protocol.md
+++ b/draft-ietf-scone-protocol.md
@@ -574,11 +574,16 @@ the network element updates the UDP checksum for the datagram.
 
 A network element needs to ensure that it sends updated rate signals
 with no more than a monitoring period ({{time}}) between each.
-Because this depends on the availability of SCONE packets,
-network elements might need to be prepared to update
-at a much higher frequency.
-Sending and updating SCONE packets at least twice per monitoring period
-ensures that signals are always available.
+Because this depends on the availability of SCONE packets
+and packet loss can cause signals to be missed,
+network elements might need to update more often.
+
+Senders that send a SCONE packet
+or network elements that update SCONE packets
+every 20&ndash;30 seconds is likely sufficient to ensure that throughput advice is not lost.
+Senders can avoid synchronization of SCONE packets,
+which might cause network elements to miss updates,
+by adding a small amount of random delay.
 
 
 ## Flows That Exceed Throughput Advice {#policing}

--- a/draft-ietf-scone-protocol.md
+++ b/draft-ietf-scone-protocol.md
@@ -291,6 +291,7 @@ SCONE packets SHOULD be included as the first packet in a datagram.  This is
 necessary in many cases for QUIC versions 1 and 2 because packets with a short
 header cannot precede any other packets.
 
+
 ## Rate Signals {#rate-signal}
 
 The Rate Signal field in SCONE uses the low 6 bits (0x3f) of the first byte.
@@ -367,10 +368,10 @@ datagram is successfully processed.  Therefore, a SCONE packet always needs to
 be coalesced with other QUIC packets.
 
 A SCONE packet is defined by the use of the longer header bit (0x80 in the first
-byte) and the SCONE protocol version (0xTBD in the next four bytes).  A SCONE
-packet MAY be discarded, along with any packets that come after it in the same
-datagram, if the Source Connection ID is not consistent with those coalesced
-packets, as specified in {{packet}}.
+byte) and the SCONE protocol version (0xSCONE1 or 0xSCONE2 in the next four
+bytes).  A SCONE packet MAY be discarded, along with any packets that come after
+it in the same datagram, if the Source Connection ID is not consistent with
+those coalesced packets, as specified in {{packet}}.
 
 A SCONE packet MUST be discarded if the Destination Connection ID does not match
 one recognized by the receiving endpoint.
@@ -378,6 +379,69 @@ one recognized by the receiving endpoint.
 If a connection uses multiple DSCP markings {{!RFC2474}},
 the throughput advice that is received on datagrams with one marking
 might not apply to datagrams that have different markings.
+
+
+## Lowest Rate Algorithm
+
+An endpoint that receives throughput advice
+might receive multiple different rate limits.
+If advice is applied by applications,
+applications MUST apply the lowest throughput advice
+received during any monitoring period; see {{time}}.
+
+Senders can ensure that their use of network capacity
+remains within throughput advice
+using a lowest rate algorithm as follows.
+
+To operate this algorithm,
+the minimal state that a sender maintains is
+* the current rate limit,
+* any state necessary to monitor throughput
+  (that is, throughput usage state, such as the state in {{sliding-window}}), and
+* the time at which that rate limit was last updated.
+
+When a SCONE packet containing updated advice is received:
+
+* If the signaled rate is the same as the current rate,
+  set the last update time to the current time.
+
+* If the signaled rate is higher than the current value,
+  then:
+
+  * If the time since the last update is greater than the monitoring period,
+    the current rate limit is increased to the received value
+    and the last update time is set to the current time.
+
+  * Otherwise, the throughput advice is not applied.
+    An implementation can optionally remember throughput advice,
+    so that it might increase send rates more quickly,
+    but this is not necessary
+    as long as there are frequent opportunities
+    to receive updated throughput signals.
+
+* If the signaled rate is lower than the current value,
+  set the current rate limit to match the advice,
+  discard all rate monitoring state,
+  and set the last update time to the current time.
+
+Senders MUST discard throughput usage state when reducing rates.
+Otherwise, data that was sent at a higher rate
+might force the updated send rate to zero; see also {{policing}}.
+Even though loss of information about recent send rate
+might result in temporarily exceeding the rates indicated by throughput advice,
+the relatively long duration of the monitoring period
+means that this is preferable to disabling sending completely.
+Senders MUST retain throughput usage state when increasing state.
+
+This approach ensures that network elements
+are able to reduce the frequency with which they send updated signals
+to as low as once per monitoring period.
+However, applying signals at a low frequency
+risks throughput advice being reset to the unbounded default
+if no SCONE packet is available for applying signals ({{apply}}),
+or the rewritten packets are lost.
+Sending the signal multiple times
+ensures that it is more likely that the signal is received.
 
 
 # Negotiating SCONE {#tp}
@@ -506,8 +570,13 @@ if is_long and (packet_version == SCONE1_VERSION or
 Once the throughput advice signal is updated,
 the network element updates the UDP checksum for the datagram.
 
+A network element needs to ensure that it sends updated rate signals
+with no more than a monitoring period ({{time}}) between each.
+Because this depends on the availability of SCONE packets,
+network elements might need to update at a much higher frequency.
 
-## Flows That Exceed Throughput Advicea
+
+## Flows That Exceed Throughput Advice {#policing}
 
 Network elements that provide throughput advice
 can monitor flows --

--- a/draft-ietf-scone-protocol.md
+++ b/draft-ietf-scone-protocol.md
@@ -573,7 +573,10 @@ the network element updates the UDP checksum for the datagram.
 A network element needs to ensure that it sends updated rate signals
 with no more than a monitoring period ({{time}}) between each.
 Because this depends on the availability of SCONE packets,
-network elements might need to update at a much higher frequency.
+network elements might need to be prepared to update
+at a much higher frequency.
+Sending and updating SCONE packets at least twice per monitoring period
+ensures that signals are always available.
 
 
 ## Flows That Exceed Throughput Advice {#policing}

--- a/ta.py
+++ b/ta.py
@@ -1,4 +1,5 @@
 from math import floor, ceil
+from time import time
 
 #>>>
 class ThroughputAdvice:
@@ -13,6 +14,8 @@ class ThroughputAdvice:
 
     self.total = 0
     self.state = [0] * self.count
+    self.advice = float('Infinity')
+    self.last_advice = t - window
 
     self.index = self.index_of(now)
     self.next_update = self.next_time(now)
@@ -22,7 +25,6 @@ class ThroughputAdvice:
 
   def next_time(self, t):
     return (floor(t / self.interval) + 1) * self.interval
-
 
   def update_time(self, t):
     if t < self.next_update:
@@ -46,6 +48,19 @@ class ThroughputAdvice:
     self.index = new_index
     self.next_update = self.next_time(t)
 
+  def set_advice(self, t, advice):
+    """Update the throughput advice based on a received signal."""
+
+    if advice < self.advice:
+      self.state = [0] * self.count
+      self.total = 0
+    elif self.advice_updated + self.interval * self.count > t:
+      # Ignore increases too soon after an update.
+      # This could be smarter about increases, but this is safe.
+      return
+    self.advice = advice
+    self.advice_updated = t
+
   def data_sent(self, t, amount):
     """Record that at time `t`, data of length `amount` was sent."""
 
@@ -53,27 +68,45 @@ class ThroughputAdvice:
     self.state[self.index] = self.state[self.index] + amount
     self.total = self.total + amount
 
-  def is_within_advice(self, t, amount, advice):
+  def is_within_advice(self, t, amount):
     """Test whether at time `t`, data of length `amount`
-       is within the provided throughput `advice`."""
+       is within the provided throughput advice."""
 
     self.update_time(t)
-    return self.total + amount <= advice
+    return self.total + amount <= self.advice
 #<<<
 
-if __name__ == "__main__":
-  ta = ThroughputAdvice(60, 1)
-  t = now()
+  def __repr__(self):
+    return f"""ThroughputAdvice {self.advice}@{self.last_advice}
+               {self.interval}*{self.count}[{self.index}] = {self.total} [{",".join([str(x) for x in self.state])}]"""
 
-  # Over 10 seconds, send 100*1000k
-  for i in [x * 0.1 for x in range(0, 100)]:
-    ta.data_sent(t + i, 1000)
+if __name__ == "__main__":
+  def fill(t, ta):
+    # Over 10 seconds, send 100*1000k
+    for i in [x * 0.1 for x in range(0, 100)]:
+      ta.data_sent(t + i, 1000)
+
+  t = time()
+  ta = ThroughputAdvice(t, 60, 1)
+  ta.set_advice(t, 100_000)
+  fill(t, ta)
 
   # 100k limit is hit
-  assert not ta.is_within_advice(t + 20, 1000, 100_000)
-  # 110k limit is OK
-  assert ta.is_within_advice(t + 20, 1000, 110_000)
-  # Out to 55 seconds
-  assert not ta.is_within_advice(t + 55, 1000, 100_000)
+  assert not ta.is_within_advice(t + 20, 1000)
+  # Out to 55 seconds, even with an update
+  ta.set_advice(t + 55, 110_000)
+  assert not ta.is_within_advice(t + 55, 1000)
   # It opens up again at 60
-  assert ta.is_within_advice(t + 60, 1000, 100_000)
+  assert ta.is_within_advice(t + 60, 1000)
+
+  t = t + 60
+  fill(t, ta)
+
+  # OK, filled up again
+  assert not ta.is_within_advice(t + 20, 1000)
+  # Expanding advice makes room for more
+  ta.set_advice(t, 110_000)
+  assert ta.is_within_advice(t + 20, 1000)
+  # So does shrinking, because it clears state
+  ta.set_advice(t, 90_000)
+  assert ta.is_within_advice(t + 20, 1000)


### PR DESCRIPTION
This approach ensures that we don't have blackout periods (an issue raised in the meeting).  But it makes the whole rate limit signaling more robust.  It also allows network elements the option of skipping updates.