### PR TITLE
Forbid insertion of SCONE packets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@ Gemfile.lock
 archive.json
 package-lock.json
 report.xml
+ta.py.excerpt
 !requirements.txt

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /.refcache
 /.venv/
 /.vscode/
+/__pycache__/
 /lib
 /node_modules/
 /versioned/

--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,4 @@ endif
 draft-ietf-scone-protocol.xml: ta.py.excerpt
 
 ta.py.excerpt: ta.py
-	sed -e '1./^#>>>/d;/^#<<</,$$d' $< > $@
+	sed -e '1,/^#>>>/d;/^#<<</,$$d' $< > $@

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,8 @@ else
 	    https://github.com/martinthomson/i-d-template $(LIBDIR)
 endif
 endif
+
+draft-ietf-scone-protocol.xml: ta.py.excerpt
+
+ta.py.excerpt: ta.py
+	sed -e '1./^#>>>/d;/^#<<</,$$d' $< > $@

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,11 @@ else
 endif
 endif
 
-draft-ietf-scone-protocol.xml: ta.py.excerpt
-
+.INTERMEDIATE: ta.py.excerpt
 ta.py.excerpt: ta.py
 	sed -e '1,/^#>>>/d;/^#<<</,$$d' $< > $@
+
+draft-ietf-scone-protocol.xml: ta.py.excerpt
+
+clean::
+	-rm -rf ta.py.excerpt

--- a/draft-ietf-scone-protocol.md
+++ b/draft-ietf-scone-protocol.md
@@ -380,7 +380,7 @@ one recognized by the receiving endpoint.
 An endpoint that receives throughput advice
 might receive multiple different rate limits.
 If advice is applied by applications,
-applications MUST apply the lowest throughput advice 
+applications MUST apply the lowest throughput advice
 received during any monitoring period; see {{time}}.
 
 Senders can ensure that their use of network capacity

--- a/draft-ietf-scone-protocol.md
+++ b/draft-ietf-scone-protocol.md
@@ -314,8 +314,16 @@ The time over which throughput advice applies is fixed
 to a period of 60 seconds.
 
 Endpoints that receive throughput advice can advise their peer of the limit.
-That peer can adhere to the limit
-by limiting the amount of data that is sent over any 60 second span.
+The sending peer can respect the advice
+by limiting the amount of data it sends over any 60 second span.
+
+Protocol participants can use a different period,
+depending on their role.
+Senders can limit their send rate over any time period
+up to 60 seconds.
+Network elements can monitor and apply limits to send rates
+using time period of at least 60 seconds.
+
 A sample algorithm for ensuring adherance to throughput advice
 is included in {{sliding-window}}.
 

--- a/draft-ietf-scone-protocol.md
+++ b/draft-ietf-scone-protocol.md
@@ -308,21 +308,21 @@ Some notable values in these ranges include:
 | 0xSCONE2 | 63          | No limit  |
 
 
-## Rough Time Span
+## Monitoring Period {#time}
 
-The time over which throughput advice applies is fixed
-to a period of 60 seconds.
+The time over which throughput advice applies is defined to be
+a period of 67 seconds.
 
 Endpoints that receive throughput advice can advise their peer of the limit.
 The sending peer can respect the advice
-by limiting the amount of data it sends over any 60 second span.
+by limiting the amount of data it sends over any 67 second span.
 
 Protocol participants can use a different period,
 depending on their role.
 Senders can limit their send rate over any time period
-up to 60 seconds.
+up to 67 seconds.
 Network elements can monitor and apply limits to send rates
-using time period of at least 60 seconds.
+using time period of at least 67 seconds.
 
 A sample algorithm for ensuring adherance to throughput advice
 is included in {{sliding-window}}.
@@ -389,6 +389,24 @@ if is_long and (packet_version == SCONE1_VERSION or packet_version == SCONE2_VER
     packet[1..5] = target_rate_version
     packet[0] = packet[0] & 0xc0 | target_rate_value
 ~~~
+
+## Flows That Exceed Throughput Advicea
+
+Network elements that provide throughput advice
+can monitor flows --
+or sets of flows that are subject to the same throughput limit --
+for adherance to that advice.
+
+In the event that a flow exceeds these limits,
+a network element could immediately start
+enforcing adherence to the advice as though it were a hard limit.
+However, this risks creating a situation where communication ceases entirely
+for a significant period of time;
+that is, up to the period defined in {{time}}.
+
+A better approach is to disregard any data that was transmitted
+before engaging any hard limits to throughput.
+This ensures that the enforcement of limits is minimally disruptive.
 
 
 # Version Interaction {#version-interaction}
@@ -716,12 +734,12 @@ Notes:
 
 One way to account for usage
 is to divide time into multiple smaller spans.
-For instance, 60 consecutive one second intervals
-or 120 half second intervals.
+For instance, 67 consecutive one second intervals
+or 134 half second intervals.
 
 The amount of data transmitted in each interval is recorded
 in a circular buffer,
-as well as the total amount over 60 seconds.
+as well as the total amount over 67 seconds.
 As time passes and new intervals are added,
 the overall total is reduced by the amount attributed to the oldest interval.
 The oldest interval is reset to zero and becomes the newest interval.

--- a/draft-ietf-scone-protocol.md
+++ b/draft-ietf-scone-protocol.md
@@ -205,14 +205,15 @@ when a network element detects a flow using more bandwidth than advertised via
 SCONE, it might switch to applying its policies for non-SCONE flows, using
 congestion control signals.
 
-The time and scope over which throughput advice applies is not specified.
-Network conditions and rate-limit policies can change in ways that make
-previously signaled advice obsolete, and there are no guarantees that
-updated advice will be sent at such events. The signaled
-advice can be assumed to apply to the flow of packets on the same UDP address
-tuple for the duration of that flow.  For rate limiting networks, rate limiting
-policies often apply on the level of a device or subscription, but endpoints
+The signaled advice can be assumed to apply
+to the flow of packets on the same UDP address tuple until updated
+or when the flow ends.
+Rate limiting policies often apply on the level of a device or subscription, but endpoints
 cannot assume that this is the case.  A separate signal can be sent for each flow.
+
+Network conditions and rate-limit policies can change in ways that make
+previously signaled advice obsolete.
+There are no guarantees that updated advice will be sent at such events.
 
 
 # Conventions and Definitions
@@ -305,6 +306,19 @@ Some notable values in these ranges include:
 | 0xSCONE2 | 56          | 100 Gbps  |
 | 0xSCONE2 | 62          | 199.5 Gbps  |
 | 0xSCONE2 | 63          | No limit  |
+
+
+## Rough Time Span
+
+The time over which throughput advice applies is fixed
+to a period of 60 seconds.
+
+Endpoints that receive throughput advice can advise their peer of the limit.
+That peer can adhere to the limit
+by limiting the amount of data that is sent over any 60 second span.
+A sample algorithm for ensuring adherance to throughput advice
+is included in {{sliding-window}}.
+
 
 ## Endpoint Processing of SCONE Packets
 
@@ -686,9 +700,30 @@ Contact:
 
 Notes:
 : (none)
-{: spacing="compact"}
+{:compact}
 
 --- back
+
+# Sliding Window for Rate Limit Monitoring {#sliding-window}
+
+One way to account for usage
+is to divide time into multiple smaller spans.
+For instance, 60 consecutive one second intervals
+or 120 half second intervals.
+
+The amount of data transmitted in each interval is recorded
+in a circular buffer,
+as well as the total amount over 60 seconds.
+As time passes and new intervals are added,
+the overall total is reduced by the amount attributed to the oldest interval.
+The oldest interval is reset to zero and becomes the newest interval.
+
+Sample code for this algorithm is included in {{x-ta}}.
+
+~~~ pseudocode
+{::include ta.py.excerpt}
+~~~
+{: #x-ta title="Sample code for managing rate limit"}
 
 # Acknowledgments
 {:numbered="false"}

--- a/draft-ietf-scone-protocol.md
+++ b/draft-ietf-scone-protocol.md
@@ -494,6 +494,14 @@ with no more than a monitoring period ({{time}}) between each.
 Because this depends on the availability of SCONE packets,
 network elements might need to update at a much higher frequency.
 
+A network element MUST NOT alter packets to add SCONE packets
+or synthesize packets that contain SCONE packets.
+The latter will not be accepted and the former,
+even if they do not exceed the path MTU as a result,
+can be detected by applications and could be ignored.
+This document does not define a mechanism to support detection,
+but one might be added in future.
+
 
 ## Flows That Exceed Throughput Advice {#policing}
 

--- a/ta.py
+++ b/ta.py
@@ -1,0 +1,80 @@
+from math import floor, ceil
+
+def now():
+  from time import time
+  return time()
+
+#>>>
+class ThroughputAdvice:
+  def __init__(self, window, interval):
+    self.interval = interval
+    self.count = floor(window / interval)
+    assert self.count == ceil(window / interval)
+
+    self.total = 0
+    self.state = [0] * self.count
+
+    time = now()
+    self.index = self.index_of(time)
+    self.next_update = self.next_time(time)
+
+  def index_of(self, t):
+    return floor(t / self.interval) % self.count
+
+  def next_time(self, t):
+    return (floor(t / self.interval) + 1) * self.interval
+
+
+  def update_time(self, t):
+    if t < self.next_update:
+      return
+    assert t + self.interval > self.next_update,\
+      "time has gone backwards"
+
+    new_index = self.index_of(t)
+    if t >= self.next_update + (self.interval * self.count):
+      self.total = 0
+      self.state = [0] * nbuckets
+    else:
+      while True:
+        self.index = (self.index + 1) % self.count
+        self.total = self.total - self.state[self.index]
+        self.state[self.index] = 0
+        if self.index == new_index:
+          break
+
+    assert sum(self.state) == self.total
+    self.index = new_index
+    self.next_update = self.next_time(t)
+
+  def data_sent(self, t, amount):
+    """Record that at time `t`, data of length `amount` was sent."""
+
+    self.update_time(t)
+    self.state[self.index] = self.state[self.index] + amount
+    self.total = self.total + amount
+
+  def is_within_advice(self, t, amount, advice):
+    """Test whether at time `t`, data of length `amount`
+       is within the provided throughput `advice`."""
+
+    self.update_time(t)
+    return self.total + amount <= advice
+#<<<
+
+if __name__ == "__main__":
+  ta = ThroughputAdvice(60, 1)
+  t = now()
+
+  # Over 10 seconds, send 100*1000k
+  for i in [x * 0.1 for x in range(0, 100)]:
+    ta.data_sent(t + i, 1000)
+
+  # 100k limit is hit
+  assert not ta.is_within_advice(t + 20, 1000, 100_000)
+  # 110k limit is OK
+  assert ta.is_within_advice(t + 20, 1000, 110_000)
+  # Out to 55 seconds
+  assert not ta.is_within_advice(t + 55, 1000, 100_000)
+  # It opens up again at 60
+  assert ta.is_within_advice(t + 60, 1000, 100_000)

--- a/ta.py
+++ b/ta.py
@@ -1,12 +1,12 @@
 from math import floor, ceil
 
-def now():
-  from time import time
-  return time()
-
 #>>>
 class ThroughputAdvice:
-  def __init__(self, window, interval):
+  def __init__(self, now, window, interval):
+    """Construct throughput advice, given a starting time `now`,
+       a duration over which to enforce `window`, and
+       an `interval` size that the window is evenly divided into."""
+
     self.interval = interval
     self.count = floor(window / interval)
     assert self.count == ceil(window / interval)
@@ -14,9 +14,8 @@ class ThroughputAdvice:
     self.total = 0
     self.state = [0] * self.count
 
-    time = now()
-    self.index = self.index_of(time)
-    self.next_update = self.next_time(time)
+    self.index = self.index_of(now)
+    self.next_update = self.next_time(now)
 
   def index_of(self, t):
     return floor(t / self.interval) % self.count


### PR DESCRIPTION
This is one potential approach to #21.  However, it does constrain things more than I think is necessary.  I tend to think that staying quiet is best, because it gives network elements the option and endpoints the choice of ignoring those inserted SCONE packets.  I wouldn't want to *encourage* that outcome though.

Closes #21.