### PR TITLE
Add an indication

### DIFF
--- a/draft-ietf-scone-protocol.md
+++ b/draft-ietf-scone-protocol.md
@@ -377,9 +377,9 @@ This indicator is derived from the first two bytes of:
 https://martinthomson.github.io/quic-pick/#seed=draft-ietf-scone-protocol-indication;field=version;codepoint=0xc813e2b1
 -->
 
-A client that is using a QUIC version that includes length-delimited packets,
+A client that uses a QUIC version that includes length-delimited packets,
 which includes QUIC versions 1 {{QUIC}} and 2 {{!QUICv2=RFC9369}},
-can include an indicator of SCONE support outside of packet protection
+can include an indicator of SCONE support
 at the end of datagrams that start a flow.
 The handshakes of these protocols ensures that
 the indication can be included in every datagram the client sends
@@ -408,9 +408,10 @@ with respect to their enforcement of their rate limit policies.
 
 ## Indications for Migrated Flows
 
-For new flows where the indicator cannot be used,
-it might be possible to send a SCONE packet instead.
-This is the case for path migration in QUIC; see {{Section 9 of QUIC}}.
+Applications MAY decide to indicate support for SCONE on new flows,
+including when migrating to a new path (see {{Section 9 of QUIC}}).
+In QUIC version 1 and 2,
+the two byte indicator cannot be used.
 
 Sending a SCONE packet for the first few packets on a new path
 gives network elements on that path the ability

--- a/draft-ietf-scone-protocol.md
+++ b/draft-ietf-scone-protocol.md
@@ -422,7 +422,8 @@ To enable this indication,
 even if an endpoint would not otherwise send SCONE packets,
 endpoints can send a SCONE packet
 any time they send a QUIC PATH_CHALLENGE or PATH_RESPONSE frame.
-This applies to both client and server endpoints.
+This applies to both client and server endpoints,
+but only if the peer has sent the transport parameter; see {{tp}}.
 
 
 # Deployment

--- a/draft-ietf-scone-protocol.md
+++ b/draft-ietf-scone-protocol.md
@@ -362,6 +362,68 @@ transport parameters, and frame types registries established in {{Sections 22.2,
 22.3, and 22.4 of QUIC}}.
 
 
+## Indicating Support on New Flows {#indication}
+
+All new flows that are initiated by a client that supports SCONE
+MUST include bytes with values 0xc8 and 0x13
+as the last two bytes of datagrams
+that commence a new flow if the protocol permits it.
+This indication MUST be sent in every datagram
+until the client receives any datagram from the server,
+at which point the client can be confident that the indication was received.
+
+<!--
+This indicator is derived from the first two bytes of:
+https://martinthomson.github.io/quic-pick/#seed=draft-ietf-scone-protocol-indication;field=version;codepoint=0xc813e2b1
+-->
+
+A client that is using a QUIC version that includes length-delimited packets,
+which includes QUIC versions 1 {{QUIC}} and 2 {{!QUICv2=RFC9369}},
+can include an indicator of SCONE support outside of packet protection
+at the end of datagrams that start a flow.
+The handshakes of these protocols ensures that
+the indication can be included in every datagram the client sends
+until it receives a response -- of any kind -- from the server.
+
+
+## Limitations of Indication
+
+This indication does not mean that SCONE signals will be respected,
+only that the client is able to negotiate SCONE.
+A server might not support SCONE
+or might choose not to send SCONE packets.
+Finally, applications might be unable to apply throughput advice
+or choose to ignore it.
+
+This indication being just two bytes
+means that there is a non-negligible risk of collision with other protocols
+or even QUIC usage without SCONE indications.
+This means that the indication alone is not sufficient to indicate
+that a flow is QUIC with the potential for SCONE support.
+
+Despite these limitations,
+having an indication might allow network elements to change their starting posture
+with respect to their enforcement of their rate limit policies.
+
+
+## Indications for Migrated Flows
+
+For new flows where the indicator cannot be used,
+it might be possible to send a SCONE packet instead.
+This is the case for path migration in QUIC; see {{Section 9 of QUIC}}.
+
+Sending a SCONE packet for the first few packets on a new path
+gives network elements on that path the ability
+to recognize the flow as being able to receive throughput advice
+and also gives the network element an opportunity to provide that throughput advice.
+
+To enable this indication,
+even if an endpoint would not otherwise send SCONE packets,
+endpoints can send a SCONE packet
+any time they send a QUIC PATH_CHALLENGE or PATH_RESPONSE frame.
+This applies to both client and server endpoints.
+
+
 # Deployment
 
 QUIC endpoints can enable the use of the SCONE protocol by sending SCONE packets


### PR DESCRIPTION
This adds a small indicator to the end of packets, so that network elements can maybe flip their posture for those flows. That requires a bit of a gamble, because the indication doesn't mean that SCONE is supported or that throughput advice will be followed, but it seems like we have some belief that this will change how the protocol might be deployed.

I didn't strongly mandate the new flow indication piece.  That's something we could do, but it turned out to be incredibly hard to specify something that works sensibly.  Tying this to PATH_CHALLENGE/PATH_RESPONSE does work, but those have more uses than initializing a flow on a new path, so the set of conditions you need to set out for when the indication is attached to a datagram end up being very complicated.

Given that we already have good reason to send SCONE packets on new paths, I don't think we need to overthink that part.

Closes #5.
Closes #23.