### PR TITLE
use 7-bit rate signal in pseudo code

### DIFF
--- a/draft-ietf-scone-protocol.md
+++ b/draft-ietf-scone-protocol.md
@@ -479,7 +479,7 @@ with an encoded throughput advice (`target_signal`).
 is_long = packet[0] & 0x80 == 0x80
 packet_version = ntohl(packet[1..5])
 if is_long and packet_version &0x7fffffff == SCONE1_VERSION:
-  packet_signal = (packet[0] & 0x3f) << 1 | packet_version >> 31
+  packet_signal = ((packet[0] & 0x3f) << 1) | (packet_version >> 31)
   if target_signal < packet_signal:
     packet[0] = packet[0] & 0xc0 | target_signal >> 1
     packet[1] = packet[1] & 0x7f | target_signal << 7

--- a/draft-ietf-scone-protocol.md
+++ b/draft-ietf-scone-protocol.md
@@ -479,7 +479,7 @@ element.
 ~~~ pseudocode
 is_long = packet[0] & 0x80 == 0x80
 packet_version = ntohl(packet[1..5])
-if is_long and packet_version &0x7fffffff == SCONE1_VERSION:
+if is_long and (packet_version & 0x7fffffff) == SCONE_VERSION_BITS:
   packet_signal = ((packet[0] & 0x3f) << 1) | (packet_version >> 31)
   if target_signal < packet_signal:
     packet[0] = (packet[0] & 0xc0) | (target_signal >> 1)

--- a/draft-ietf-scone-protocol.md
+++ b/draft-ietf-scone-protocol.md
@@ -463,8 +463,8 @@ QUIC endpoints can enable the use of the SCONE protocol by sending SCONE packets
 A network element detects a SCONE packet by observing that a packet has a QUIC
 long header and one of the SCONE protocol versions (0x6f7dc0fd or 0xef7dc0fd).
 
-A network element then conditionally replaces the Version field and the Rate
-Signal field with values of its choosing.
+A network element then conditionally replaces the most significant bit of the 
+Version field and the Rate Signal High Bits field with values of its choosing.
 
 A network element might receive a packet that already includes a rate signal.
 The network element replaces the rate signal if it wishes to signal a lower
@@ -472,8 +472,9 @@ rate limit; otherwise, the original values are retained, preserving the signal
 from the network element with the lower policy.
 
 The following pseudocode indicates how a network element might detect a SCONE
-packet and replace an existing rate signal,
-with an encoded throughput advice (`target_signal`).
+packet and replace the existing rate signal (`packet_signal`) with a new rate
+signal (`target_signal`) that encodes the throughput advice of this network
+element.
 
 ~~~ pseudocode
 is_long = packet[0] & 0x80 == 0x80

--- a/draft-ietf-scone-protocol.md
+++ b/draft-ietf-scone-protocol.md
@@ -481,8 +481,8 @@ packet_version = ntohl(packet[1..5])
 if is_long and packet_version &0x7fffffff == SCONE1_VERSION:
   packet_signal = ((packet[0] & 0x3f) << 1) | (packet_version >> 31)
   if target_signal < packet_signal:
-    packet[0] = packet[0] & 0xc0 | target_signal >> 1
-    packet[1] = packet[1] & 0x7f | target_signal << 7
+    packet[0] = (packet[0] & 0xc0) | (target_signal >> 1)
+    packet[1] = (packet[1] & 0x7f) | (target_signal << 7)
 ~~~
 
 Once the throughput advice signal is updated,

--- a/draft-ietf-scone-protocol.md
+++ b/draft-ietf-scone-protocol.md
@@ -463,7 +463,7 @@ QUIC endpoints can enable the use of the SCONE protocol by sending SCONE packets
 A network element detects a SCONE packet by observing that a packet has a QUIC
 long header and one of the SCONE protocol versions (0x6f7dc0fd or 0xef7dc0fd).
 
-A network element then conditionally replaces the most significant bit of the 
+A network element then conditionally replaces the most significant bit of the
 Version field and the Rate Signal High Bits field with values of its choosing.
 
 A network element might receive a packet that already includes a rate signal.


### PR DESCRIPTION
Given the current design, it makes sense to compare the rate signals directly. 
This is not the most optimal code, but trying to prioritize readability. 
