### PR TITLE
instant bitrate adaptation

### DIFF
--- a/draft-ietf-scone-protocol.md
+++ b/draft-ietf-scone-protocol.md
@@ -721,7 +721,7 @@ signals can send SCONE packets at any time.  This is a decision that a sender
 makes when constructing datagrams.
 
 When sending SCONE packets, enpoints MUST include the SCONE packet as the first
-packet in a datagram.
+packet in a datagram, coalesced with additional packets.
 
 Upon confirmation that the peer is willing to receive SCONE packets, an endpoint
 SHOULD include SCONE packets in the first few UDP datagrams that it sends. Doing


### PR DESCRIPTION
As discussed in #68, it would be helpful to the applications if the bitrate advice is available right after the handshake.

To achieve that, this pull request encourages endpoints to send a small number of SCONE packets ASAP and network elements to update them.

For the advice to endpoints, I've removed redundant text that existed elsewhere (namely section 5 and 5.3), adopting MUST from the sentence removed.

For the advice to network elements, I avoided use of RFC2119 verbs, following the previous paragraph.

Closes #68.