### PR TITLE
SCONE network element description

### DIFF
--- a/draft-ietf-scone-protocol.md
+++ b/draft-ietf-scone-protocol.md
@@ -76,7 +76,7 @@ accessible to endpoints, allows applications to use this information when
 adapting their send rate.
 
 In access networks, the network elements -those networking entities along the 
-path of appication traffic flows that have access to the IP packets- 
+path of application traffic flows that have access to the IP packets- 
 could provide advice to endpoints that can help guide application use of 
 network capacity, separate from any signals that are intended to influence 
 congestion response.


### PR DESCRIPTION
Tried to capture the comments and discussions in the simplest way possible.

Includes :

- simplistic defition of a Network element
- coined the term "SCONE Network element" which is a special network element capable of handling SCONE protocol.
- s/network element/SCONE Network element, throughout the document.
- changes figure to depict SCONE Network element.