### PR TITLE
Rework defense text on VPN/Proxy privacy

### DIFF
--- a/draft-ietf-scone-protocol.md
+++ b/draft-ietf-scone-protocol.md
@@ -1060,16 +1060,20 @@ the attacker to link the altered flow to the client.
                   \
                Observe change
 ~~~
+{: #f-vpn title="Client identification attack on VPN or proxy"}
 
-An attacker that can manipulate SCONE headers can also simulate
-congestion signals by dropping packets or by setting the ECN CE bit.
-That will also likely result in changes in the congestion response by
-the affected client.
+An attacker that can manipulate SCONE headers might
+cause an observable change in sending behavior; see {{f-vpn}}.
+Though clients that use a VPN or proxy might choose to disable SCONE,
+removing SCONE signals is of little help against this form of attack.
+Lost or marked packets are likely to produce a congestion control response,
+which are alternative methods available to an attacker
+seeking to match flows.
 
-A VPN or proxy could defend against this style of attack by removing SCONE (and
-ECN) signals. There are few reasons to provide per-flow throughput advice in
-that situation.  Endpoints might also either disable this feature or ignore any
-signals when they are aware of the use of a VPN or proxy.
+An effective, but wasteful, defense is to provide cover traffic
+between the client and intermediary
+to mask changes in sending rate on tunneled flows.
+
 
 # IANA Considerations {#iana}
 

--- a/draft-ietf-scone-protocol.md
+++ b/draft-ietf-scone-protocol.md
@@ -1066,7 +1066,7 @@ An attacker that can manipulate SCONE headers might
 cause an observable change in sending behavior; see {{f-vpn}}.
 Though clients that use a VPN or proxy might choose to disable SCONE,
 removing SCONE signals is of little help against this form of attack.
-Lost or marked packets are likely to produce a congestion control response,
+Lost or ECN-marked packets are likely to produce a congestion control response,
 which are alternative methods available to an attacker
 seeking to match flows.
 


### PR DESCRIPTION
As noted by Mirja, if the attacker can drop/CE-mark packets, there isn't much point in suggesting that SCONE be disabled. Any attacker that can tweak SCONE is almost certainly able to drop packets or apply ECN markings.

The best defense here is wasteful: if congestion/SCONE causes the rate to drop on the e2e connection, then take any reduction and send dummy traffic between the proxy and client.  There are challenges (in the server-to-client direction, this is something the proxy needs to do, but how does it know to do that?) but we don't need to get into that.

Closes #134.