### PR TITLE
Grammatical error

### DIFF
--- a/draft-ietf-scone-protocol.md
+++ b/draft-ietf-scone-protocol.md
@@ -290,7 +290,7 @@ Endpoints that receive this signal therefore need to treat the information as ad
 The fact that an endpoint requests throughput advice does not necessarily mean
 that it will adhere to advice; in some cases, the endpoint cannot. For
 example, a flow could initially be used to serve video chunks, with the client
-selecting appropriate chunks based on received advice, but later switch to a
+selecting chunks of different bitrates based on received advice, but later switch to a
 bulk download that cannot be similarly controlled. Composite flows
 from multiple applications, such as tunneled flows, might only have a subset of
 the involved applications that are capable of handling SCONE signals. Therefore,

--- a/draft-ietf-scone-protocol.md
+++ b/draft-ietf-scone-protocol.md
@@ -291,7 +291,7 @@ The fact that an endpoint requests throughput advice does not necessarily mean
 that it will adhere to advice; in some cases, the endpoint cannot. For
 example, a flow could initially be used to serve video chunks, with the client
 selecting appropriate chunks based on received advice, but later switch to a
-bulk download for which bitrate adaptation that cannot be similarly controlled. Composite flows
+bulk download that cannot be similarly controlled. Composite flows
 from multiple applications, such as tunneled flows, might only have a subset of
 the involved applications that are capable of handling SCONE signals. Therefore,
 when a network element detects that throughput exceeds the advertised throughput advice,


### PR DESCRIPTION
Stuart pointed at this text and it doesn't read well.

This does nothing to address the concern raised in that email, but I thought it worth getting the language fixed anyway.