### PR TITLE
Eliminate ambiguity around SCONE packets and stateless resets

### DIFF
--- a/draft-ietf-scone-protocol.md
+++ b/draft-ietf-scone-protocol.md
@@ -483,16 +483,16 @@ A SCONE packet is defined by the use of the long header bit (0x80 in the first
 byte) and the SCONE protocol version (0x6f7dc0fd or 0xef7dc0fd in the next four
 bytes). The 7-bit Rate Signal can be extracted by combining the low 6 bits
 of the first byte with the most significant bit of the version field. A SCONE
-packet MAY be discarded, along with any packets that come after it in the same
-datagram, if the Source Connection ID is not consistent with those coalesced
-packets, as specified in {{packet}}.
+packet MUST be discarded if the Destination Connection ID is not consistent with
+those coalesced packets, as specified in {{packet}}. Similarly, if the Source
+Connection ID is inconsistent, the SCONE packet MAY be discarded.
+
+When discarding a SCONE packet due to inconsistent Connection IDs, endpoints MAY
+also discard the QUIC packets that were coalesced into the same datagram.
 
 A receiver MAY discard a datagram that contains more than one SCONE packet.
 
 A SCONE packet is discarded if the rate signal is unknown (127).
-
-A SCONE packet MUST be discarded if the Destination Connection ID does not match
-one recognized by the receiving endpoint.
 
 If a connection uses multiple DSCP markings {{!RFC2474}},
 the throughput advice that is received on datagrams with one marking


### PR DESCRIPTION
Section 5.3 currently states that a SCONE packet MUST be ignored unless another packet in the same datagram is successfully processed (1st paragraph), then goes on to say:
* If the Source Connection ID is inconsistent among the packets within a datagram, the SCONE packet MAY be discarded, along with the other coalesced packets.
* If the Destination Connection ID does not match one recognized by the receiving endpoint, the SCONE packet MUST be discarded.

These were not written in parallel. The SCID rule is a consistency check against the coalesced packets orthogonal to the ignore-unless-processed rule. In contrast, the DCID rule was framed around recognition of the connection, trying to combine the consistency check and the ignore-unless-processed rule into a single sentence. That recognition-based wording is what caused the confusion in #149 about whether a stateless reset may be generated in response to a 1-RTT packet coalesced with a SCONE packet.

This PR reframes the Destination Connection ID handling as a consistency check, parallel to the Source Connection ID, the only difference being MUST (DCID) vs. MAY (SCID). The case the old text covered (i.e., a consistent DCID that the endpoint does not currently recognize) remains handled by the 1st paragraph. The confusion around stateless resets is resolved, because handling of the coalesced packets is no longer tied to the recognition of DCID, and is instead left to ordinary QUIC processing.

Closes #149.